### PR TITLE
Fix isolate_ball cropping and add unit tests

### DIFF
--- a/IsolateCode.py
+++ b/IsolateCode.py
@@ -17,8 +17,14 @@ def isolate_ball(
     Returns:
         ball_crop: Cropped image of the ball.
     """
-    # Auto-detect if needed
-    if not getattr(ball, 'x', None) or not getattr(ball, 'y', None) or not getattr(ball, 'measured_radius_pixels', None):
+    # Auto-detect if needed. The original implementation treated zero values as
+    # missing which caused valid coordinates near the image origin to trigger
+    # detection again. Only ``None`` should be considered "missing".
+    if (
+        getattr(ball, "x", None) is None
+        or getattr(ball, "y", None) is None
+        or getattr(ball, "measured_radius_pixels", None) is None
+    ):
         circles = cv2.HoughCircles(
             img, cv2.HOUGH_GRADIENT, dp=1.2, minDist=50,
             param1=100, param2=30, minRadius=30, maxRadius=70
@@ -33,10 +39,10 @@ def isolate_ball(
             raise ValueError("No ball detected in image!")
 
     # Compute crop dimensions
-    r = ball.measured_radius_pixels
-    x1 = int(ball.x - r)
-    y1 = int(ball.y - r)
-    w = h = 2 * r
+    r = int(round(ball.measured_radius_pixels))
+    x1 = int(round(ball.x - r))
+    y1 = int(round(ball.y - r))
+    w = h = int(2 * r)
 
     # Clip to image bounds
     x1 = max(0, min(x1, img.shape[1] - w - 1))

--- a/test_isolate_ball.py
+++ b/test_isolate_ball.py
@@ -1,51 +1,20 @@
-import cv2
 import numpy as np
+import cv2
 from IsolateCode import isolate_ball
 from GolfBall import GolfBall
 
-def test_isolate_ball():
-    # Load the test image
-    image_path = r"C:\Users\theka\Downloads\GCFive\Images\gs_log_img__log_ball_final_found_ball_img.png"
-    image = cv2.imread(image_path, cv2.IMREAD_GRAYSCALE)
-    
-    if image is None:
-        print("Error: Could not load image")
-        return
-    
-    # Create a dummy GolfBall object with necessary attributes
-    ball = GolfBall(
-        x=image.shape[1]//2,
-        y=image.shape[0]//2,
-        measured_radius_pixels=50,
-        angles_camera_ortho_perspective=(0.0, 0.0, 0.0)
-    )
-    
-    # Test the isolate_ball function
-    ball_image, local_ball = isolate_ball(image, ball)
-    
-    # Display results
-    cv2.imshow("Original Image", image)
-    cv2.imshow("Isolated Ball", ball_image)
-    cv2.waitKey(0)
-    cv2.destroyAllWindows()
-    
-    # Print information about the isolated ball
-    print(f"Isolated ball shape: {ball_image.shape}")
-    print(f"Local ball center: ({local_ball.x}, {local_ball.y})")
-    print(f"Local ball radius: {local_ball.measured_radius_pixels}")
+def test_isolate_ball_synthetic_center():
+    img = np.zeros((100, 100), dtype=np.uint8)
+    cv2.circle(img, (50, 50), 20, 255, -1)
+    ball = GolfBall(x=50, y=50, measured_radius_pixels=20, angles_camera_ortho_perspective=(0.0, 0.0, 0.0))
+    crop = isolate_ball(img, ball)
+    assert crop.shape == (40, 40)
+    assert crop[20, 20] == 255
 
-if __name__ == "__main__":
-    test_isolate_ball()
-
-# Quick test
-image = cv2.imread(r"C:\Users\theka\Downloads\GCFive\Images\gs_log_img__log_ball_final_found_ball_img.png", cv2.IMREAD_GRAYSCALE)
-ball = GolfBall(
-    x=image.shape[1]//2,
-    y=image.shape[0]//2,
-    measured_radius_pixels=50,
-    angles_camera_ortho_perspective=(0.0, 0.0, 0.0)
-)
-ball_image, _ = isolate_ball(image, ball)
-cv2.imshow("Quick Test", ball_image)
-cv2.waitKey(0)
-cv2.destroyAllWindows() 
+def test_isolate_ball_zero_coordinates():
+    img = np.zeros((30, 30), dtype=np.uint8)
+    cv2.circle(img, (5, 5), 4, 255, -1)
+    ball = GolfBall(x=5, y=5, measured_radius_pixels=4, angles_camera_ortho_perspective=(0.0, 0.0, 0.0))
+    crop = isolate_ball(img, ball)
+    assert crop.shape == (8, 8)
+    assert crop[4, 4] == 255


### PR DESCRIPTION
## Summary
- correct detection of missing ball parameters in `isolate_ball`
- ensure cropping dimensions are integers
- rewrite tests to use synthetic images

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f855af66883318846868e6c7761cd