### PR TITLE
Add Python trajectory visualizer

### DIFF
--- a/JaySimG_translation/README.md
+++ b/JaySimG_translation/README.md
@@ -1,0 +1,12 @@
+This folder contains a translation of the Godot scripts from the JaySimG project.
+The original project can be found at: https://github.com/jhauck2/JaySimG
+
+The scripts here provide a Python approximation of the `ball.gd`, `ball_trail.gd`,
+and `range.gd` Godot scripts. They are not a drop-in replacement for the Godot
+implementation but aim to replicate the core logic so that the physics model can
+be run in a plain Python environment.
+
+## Visualizing a sample shot
+Run `python -m JaySimG_translation.visualize_flight` to simulate a default shot
+and save a `trajectory.png` image along with printed carry distance, time of
+flight, and apex height.

--- a/JaySimG_translation/ball.gd
+++ b/JaySimG_translation/ball.gd
@@ -1,0 +1,183 @@
+extends CharacterBody3D
+
+var omega := Vector3.ZERO
+var rolling = false
+var on_ground := false
+var floor_norm := Vector3(0.0, 1.0, 0.0)
+
+var mass = 0.04592623
+var radius = 0.021335
+var A = PI*radius*radius # Cross-sectional area
+var I = 0.4*mass*radius*radius # Moment of inertia
+var u_k = 0.4 # friction coefficient with the ground
+var u_kr = 0.2 # friction coefficient with the ground while rolling
+
+var rho = 1.225 # Air density (kg/m^3)
+var nu = 0.00001789 # Air Viscosity
+var nu_k = 0.0000146 # Air Kinematic Viscosity
+var nu_g = 0.0012 # Grass Viscosity (estimate somewhere between air and water)
+
+enum State {REST, FLIGHT, ROLLOUT}
+var state : State = State.REST
+
+signal rest
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass
+
+
+func _process(_delta: float) -> void:
+	pass
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _physics_process(delta: float) -> void:
+	on_ground = position.y < 0.022
+	
+	var F_g := Vector3(0.0, -9.81*mass, 0) # force of gravity
+	var F_m := Vector3.ZERO # Magnus force
+	var F_d := Vector3.ZERO # Drag force
+	var F_f := Vector3.ZERO # Frictional force
+	var F_gd := Vector3.ZERO # Drag force from grass
+	
+	var T_d := Vector3.ZERO # Viscous torque
+	var T_f := Vector3.ZERO # Frictional torque
+	var T_g := Vector3.ZERO # Grass drag torque
+	
+	if on_ground:
+		# Force of viscous drag from grass
+		F_gd = velocity*(-6*PI*radius*nu_g)
+		F_gd.y = 0.0
+		
+		# velocity of the bottom of the ball relative to the ground with spin included
+		var b_vel : Vector3 = floor_norm.cross(omega)*radius
+		b_vel = b_vel + velocity
+		if b_vel.length() < 0.05: # rolling without slipping
+			b_vel = velocity.normalized()
+			F_f = b_vel*(-u_k*mass*9.81)
+		else: # ball slipping
+			b_vel = b_vel.normalized()
+			F_f = b_vel*(-u_k*mass*9.81)
+			T_f = (floor_norm*-radius).cross(F_f)
+			
+		# Viscous Torque
+		T_g = omega.normalized()*-6.0*PI*radius*nu_g
+	else: # ball in air
+		var speed := velocity.length()
+		var spin := 0.0
+		if speed > 0.5:
+			spin = omega.length()*radius/speed
+			
+		var Re : float = speed*radius*2.0/nu_k
+		
+		# Magnus and drag coefficients
+		# original
+		#var S : float = 0.5*rho*PI*radius*radius*radius*(-3.25*spin+1.99)
+		#first tweak
+		var S : float = 0.5*rho*PI*radius*radius*radius*(-2.4*spin+1.75)
+		
+		
+		var Cd := 0.0 # Drag coefficient
+		if Re < 87500.0:
+			Cd = 0.000000000129*Re*Re - 0.0000259*Re + 1.50
+		else:
+			Cd = 0.0000000000191*Re*Re - 0.0000054*Re + 0.56
+		
+		# Magnus force
+		F_m = omega.cross(velocity)*S
+		# Viscous Torque
+		var Cdm := Cd/3.0
+		#T_d = omega.normalized()*-0.5*Cdm*rho*A
+		T_d = -8.0*PI*nu*radius*radius*radius*omega
+		
+		# Drag force
+		F_d = velocity*-speed*Cd*rho*A/2.0*1.3 # *1.05 factor used to dial in distances
+		
+	# Total force
+	var F : Vector3 = F_g + F_d + F_m + F_f + F_gd
+	
+	# Total torque
+	var T : Vector3 = T_d + T_f + T_g 
+	
+	velocity = velocity + F/mass*delta
+	omega = omega + T/I*delta
+	
+	
+	# Collisions
+	var collision = move_and_collide(velocity*delta)
+	if collision:
+		if velocity.length() > 0.5:
+			velocity = bounce(velocity, collision.get_normal())
+		else:
+			velocity = Vector3.ZERO
+			state = State.REST
+			emit_signal("rest")
+			
+
+
+func bounce(vel, normal) -> Vector3:
+	# component of velocity parallel to floor normal
+	var vel_norm : Vector3 = vel.project(normal)
+	var speed_norm : float = vel_norm.length()
+	# component of velocity orthoganal to normal
+	var vel_orth : Vector3 = vel - vel_norm
+	var speed_orth : float = vel_orth.length()
+	#component of angular velocity parallel to normal
+	var omg_norm : Vector3 = omega.project(normal)
+	# component of angular velocity orthoganal to normal
+	var omg_orth : Vector3 = omega - omg_norm
+	
+	var speed : float = velocity.length()
+	var theta_1 : float = velocity.angle_to(normal)
+	var theta_c : float = 15.4 * speed * theta_1 / 18.6 / 44.4 # Eq 18 from reference
+	
+	# final orthoganal speed
+	var v2_orth = 5.0/7.0*speed*sin(theta_1-theta_c) - 2.0*radius*omg_norm.length()/7.0
+	# orthoganal restitution
+	if speed_orth < 0.01:
+		vel_orth = Vector3.ZERO
+	else:
+		vel_orth = vel_orth.limit_length(v2_orth)
+		
+	# final orthoganal angular velocity
+	var w2h : float = v2_orth/radius
+	# orthoganal angular restitution
+	if omg_orth.length() < 0.1:
+		omg_orth = Vector3.ZERO
+	else:
+		omg_orth = omg_orth.limit_length(w2h)
+		
+	# normal restitution
+	var e : float = 0.0
+	if speed_norm < 20.0:
+		e = 0.12
+	else:
+		e = 0.510 - 0.0375*speed_norm + 0.000903*speed_norm*speed_norm
+	
+	vel_norm = vel_norm*-e
+	
+	omega = omg_norm + omg_orth
+	
+	return vel_norm + vel_orth
+	
+
+func hit():
+	# 8 iron test shot - 100 mph, 20.8 deg launch, 1.7 deg horz launch, 7494 rpm, 2.7 degree spin axis offset
+	state = State.FLIGHT
+	position = Vector3.ZERO
+	velocity = Vector3(44.7*cos(20.8*PI/180.0)*cos(1.7*PI/180.0), 44.7*sin(20.8*PI/180.0), 44.7*sin(1.7*PI/180.0))
+	omega = Vector3(0.0, 784.0*sin(2.7*PI/180.0), 784.0*cos(2.7*PI/180.0))
+	
+func hit_from_data(data : Dictionary):
+	position = Vector3(0.0, 0.05, 0.0)
+	velocity = Vector3(data["Speed"]*0.44704, 0, 0).rotated(
+					Vector3(0.0, 0.0, 1.0), data["VLA"]*PI/180.0).rotated(
+						Vector3(1.0, 0.0, 0.0), data["HLA"]*PI/180.0)
+	omega = Vector3(0.0, 0.0, data["TotalSpin"]*0.10472).rotated(Vector3(1.0, 0.0, 0.0), -data["SpinAxis"]*PI/180)
+	
+	
+func reset():
+	position = Vector3(0.0, 0.1, 0.0)
+	velocity = Vector3.ZERO
+	omega = Vector3.ZERO
+	state = State.REST

--- a/JaySimG_translation/ball.py
+++ b/JaySimG_translation/ball.py
@@ -1,0 +1,183 @@
+from dataclasses import dataclass, field
+from typing import Tuple
+import numpy as np
+from .vector import vec3, length, normalized, cross, dot
+
+
+@dataclass
+class Ball:
+    position: np.ndarray = field(default_factory=lambda: vec3())
+    velocity: np.ndarray = field(default_factory=lambda: vec3())
+    omega: np.ndarray = field(default_factory=lambda: vec3())
+
+    mass: float = 0.04592623
+    radius: float = 0.021335
+    A: float = field(init=False)  # cross-sectional area
+    I: float = field(init=False)  # moment of inertia
+    u_k: float = 0.4  # friction coefficient
+    u_kr: float = 0.2
+
+    rho: float = 1.225
+    nu: float = 0.00001789
+    nu_k: float = 0.0000146
+    nu_g: float = 0.0012
+
+    def __post_init__(self):
+        self.A = np.pi * self.radius ** 2
+        self.I = 0.4 * self.mass * self.radius ** 2
+
+    def reset(self):
+        self.position[:] = vec3(0.0, 0.1, 0.0)
+        self.velocity[:] = vec3()
+        self.omega[:] = vec3()
+
+    def hit(self):
+        self.position[:] = vec3()
+        v = 44.7
+        self.velocity[:] = vec3(
+            v * np.cos(np.radians(20.8)) * np.cos(np.radians(1.7)),
+            v * np.sin(np.radians(20.8)),
+            v * np.sin(np.radians(1.7)),
+        )
+        self.omega[:] = vec3(
+            0.0,
+            784.0 * np.sin(np.radians(2.7)),
+            784.0 * np.cos(np.radians(2.7)),
+        )
+
+    def hit_from_data(self, data: dict):
+        self.position[:] = vec3(0.0, 0.05, 0.0)
+        v = vec3(data["Speed"] * 0.44704, 0.0, 0.0)
+        # vertical launch angle
+        rot_v = np.radians(data["VLA"])
+        rot_h = np.radians(data["HLA"])
+        # rotate around z then x
+        Rz = rotation_matrix(vec3(0.0, 0.0, 1.0), rot_v)
+        Rx = rotation_matrix(vec3(1.0, 0.0, 0.0), rot_h)
+        self.velocity[:] = Rx @ (Rz @ v)
+        spin = vec3(0.0, 0.0, data["TotalSpin"] * 0.10472)
+        axis = rotation_matrix(vec3(1.0, 0.0, 0.0), -np.radians(data["SpinAxis"]))
+        self.omega[:] = axis @ spin
+
+    def update(self, delta: float):
+        on_ground = self.position[1] < 0.022
+
+        F_g = vec3(0.0, -9.81 * self.mass, 0.0)
+        F_m = vec3()
+        F_d = vec3()
+        F_f = vec3()
+        F_gd = vec3()
+
+        T_d = vec3()
+        T_f = vec3()
+        T_g = vec3()
+
+        if on_ground:
+            F_gd = -6 * np.pi * self.radius * self.nu_g * self.velocity
+            F_gd[1] = 0.0
+            b_vel = cross(vec3(0.0, 1.0, 0.0), self.omega) * self.radius
+            b_vel = b_vel + self.velocity
+            if length(b_vel) < 0.05:
+                b_dir = normalized(self.velocity)
+                F_f = -self.u_k * self.mass * 9.81 * b_dir
+            else:
+                b_dir = normalized(b_vel)
+                F_f = -self.u_k * self.mass * 9.81 * b_dir
+                T_f = cross(vec3(0.0, -self.radius, 0.0), F_f)
+            if length(self.omega) != 0:
+                T_g = -6.0 * np.pi * self.radius * self.nu_g * normalized(self.omega)
+        else:
+            speed = length(self.velocity)
+            spin = 0.0
+            if speed > 0.5:
+                spin = length(self.omega) * self.radius / speed
+            Re = speed * self.radius * 2.0 / self.nu_k
+            S = 0.5 * self.rho * np.pi * self.radius ** 3 * (-2.4 * spin + 1.75)
+            if Re < 87500.0:
+                Cd = 0.000000000129 * Re ** 2 - 0.0000259 * Re + 1.50
+            else:
+                Cd = 0.0000000000191 * Re ** 2 - 0.0000054 * Re + 0.56
+            F_m = cross(self.omega, self.velocity) * S
+            T_d = -8.0 * np.pi * self.nu * self.radius ** 3 * self.omega
+            F_d = -self.velocity * speed * Cd * self.rho * self.A / 2.0 * 1.3
+
+        F = F_g + F_d + F_m + F_f + F_gd
+        T = T_d + T_f + T_g
+
+        self.velocity += (F / self.mass) * delta
+        self.omega += (T / self.I) * delta
+
+        # simple ground collision
+        next_pos = self.position + self.velocity * delta
+        if next_pos[1] < 0.0 and self.velocity[1] < 0:
+            self.velocity = self.bounce(self.velocity, vec3(0.0, 1.0, 0.0))
+            next_pos[1] = 0.0
+            # damp very small bounces so the ball can come to rest
+            if abs(self.velocity[1]) < 0.05:
+                self.velocity[1] = 0.0
+                if length(self.velocity) < 0.1:
+                    self.velocity[:] = vec3()
+        self.position[:] = next_pos
+
+    def bounce(self, vel, normal):
+        vel_norm = project(vel, normal)
+        speed_norm = length(vel_norm)
+        vel_orth = vel - vel_norm
+        speed_orth = length(vel_orth)
+        omg_norm = project(self.omega, normal)
+        omg_orth = self.omega - omg_norm
+
+        speed = length(self.velocity)
+        theta_1 = angle_between(self.velocity, normal)
+        theta_c = 15.4 * speed * theta_1 / 18.6 / 44.4
+        v2_orth = 5.0/7.0*speed*np.sin(theta_1-theta_c) - 2.0*self.radius*length(omg_norm)/7.0
+        if speed_orth < 0.01:
+            vel_orth = vec3()
+        else:
+            vel_orth = limit_length(vel_orth, v2_orth)
+        w2h = v2_orth/self.radius
+        if length(omg_orth) < 0.1:
+            omg_orth = vec3()
+        else:
+            omg_orth = limit_length(omg_orth, w2h)
+        if speed_norm < 20.0:
+            e = 0.12
+        else:
+            e = 0.510 - 0.0375*speed_norm + 0.000903*speed_norm*speed_norm
+        vel_norm = vel_norm * -e
+        self.omega = omg_norm + omg_orth
+        return vel_norm + vel_orth
+
+
+def project(v, n):
+    n_norm = normalized(n)
+    return n_norm * dot(v, n_norm)
+
+
+def angle_between(a, b):
+    a_n = normalized(a)
+    b_n = normalized(b)
+    dot_val = np.clip(dot(a_n, b_n), -1.0, 1.0)
+    return np.arccos(dot_val)
+
+
+def limit_length(v, l):
+    cur = length(v)
+    if cur == 0:
+        return v
+    if cur > abs(l):
+        return normalized(v) * l
+    return v
+
+
+def rotation_matrix(axis, angle):
+    axis = normalized(axis)
+    x, y, z = axis
+    c = np.cos(angle)
+    s = np.sin(angle)
+    C = 1 - c
+    return np.array([
+        [x*x*C + c,   x*y*C - z*s, x*z*C + y*s],
+        [y*x*C + z*s, y*y*C + c,   y*z*C - x*s],
+        [z*x*C - y*s, z*y*C + x*s, z*z*C + c  ],
+    ])

--- a/JaySimG_translation/ball_trail.gd
+++ b/JaySimG_translation/ball_trail.gd
@@ -1,0 +1,34 @@
+extends MeshInstance3D
+
+var points : Array = [Vector3.ZERO, Vector3.ZERO]
+var color : Color = Color.RED
+var material : ORMMaterial3D = ORMMaterial3D.new()
+
+
+func _ready():
+	mesh = ImmediateMesh.new()
+	material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	
+func _process(_delta):
+	draw()
+
+func setColor(a):
+	color = a
+	material.albedo_color = color
+
+func draw():
+	mesh.clear_surfaces()
+	mesh.surface_begin(Mesh.PRIMITIVE_LINE_STRIP, material)
+	for point in points:
+		mesh.surface_add_vertex(point)
+	mesh.surface_end()
+	
+	material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	material.albedo_color = color
+
+func add_point(point: Vector3):
+	#points.append(points[-1])
+	points.append(point)
+
+func clear_points():
+	points = [Vector3.ZERO, Vector3.ZERO]

--- a/JaySimG_translation/ball_trail.py
+++ b/JaySimG_translation/ball_trail.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass, field
+import numpy as np
+from .vector import vec3
+
+
+@dataclass
+class BallTrail:
+    points: list = field(default_factory=lambda: [vec3(), vec3()])
+
+    def add_point(self, point):
+        self.points.append(np.array(point, dtype=float))
+
+    def clear_points(self):
+        self.points = [vec3(), vec3()]

--- a/JaySimG_translation/range.gd
+++ b/JaySimG_translation/range.gd
@@ -1,0 +1,78 @@
+extends Node3D
+
+var track_points : bool = false
+var trail_timer : float = 0.0
+var trail_resolution : float = 0.1
+
+var tcp_server : TCPServer = TCPServer.new()
+var tcp_connection : StreamPeerTCP = null
+var tcp_connected : bool = false
+var tcp_data : Array = []
+var tcp_string : String = ""
+var shot_data : Dictionary
+var apex := 0
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	tcp_server.listen(49152)
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	# TCP Server
+	if not tcp_connected:
+		tcp_connection = tcp_server.take_connection()
+		if tcp_connection:
+			print("We have a tcp connection at " + tcp_connection.get_connected_host())
+			tcp_connected = true
+	else: # read from the connection
+		tcp_connection.poll()
+		var tcp_status : StreamPeerTCP.Status = tcp_connection.get_status()
+		if tcp_status == StreamPeerTCP.STATUS_NONE: #disconnected
+			tcp_connected = false
+			print("tcp disconnected")
+		elif tcp_status == StreamPeerTCP.STATUS_CONNECTED:
+			var bytes_avail := 0
+			tcp_data = []
+			bytes_avail = tcp_connection.get_available_bytes()
+			if bytes_avail > 0:
+				tcp_data = tcp_connection.get_data(bytes_avail)
+			if tcp_data:
+				tcp_string = ""
+				for byte in tcp_data[1]:
+					tcp_string += char(byte)
+				
+				var json := JSON.new()
+				var error := json.parse(tcp_string)
+				if error == OK:
+					shot_data = json.data
+					if shot_data["ShotDataOptions"]["ContainsBallData"]:
+						$BallTrail.call_deferred("clear_points")
+						$Ball.call_deferred("hit_from_data", shot_data["BallData"])
+						track_points = true
+						$BallTrail.add_point($Ball.position)
+				
+	
+	$VBoxContainer/Label.text = "Distance: " + str(int(Vector2($Ball.position.x, $Ball.position.z).length()*1.09361)) + " yd"
+	apex = max(apex, int($Ball.position.y*1.09361))
+	$VBoxContainer/Label2.text = "Apex: " + str(apex*3) + " ft"
+	if Input.is_action_just_pressed("hit"):
+		$BallTrail.call_deferred("clear_points")
+		$Ball.call_deferred("hit")
+		track_points = true
+		$BallTrail.add_point($Ball.position)
+	if Input.is_action_just_pressed("reset"):
+		$Ball.call_deferred("reset")
+		apex = 0
+		track_points = false
+		$BallTrail.clear_points()
+		
+	if track_points:
+		trail_timer += delta
+		if trail_timer >= trail_resolution:
+			$BallTrail.add_point($Ball.position)
+			trail_timer = 0.0
+
+
+func _on_ball_rest() -> void:
+	track_points = false

--- a/JaySimG_translation/range.py
+++ b/JaySimG_translation/range.py
@@ -1,0 +1,71 @@
+import json
+import socket
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .ball import Ball
+from .ball_trail import BallTrail
+
+
+@dataclass
+class RangeSim:
+    host: str = "0.0.0.0"
+    port: int = 49152
+    track_points: bool = False
+    trail_resolution: float = 0.1
+    _trail_timer: float = 0.0
+    _apex: float = 0.0
+    ball: Ball = field(default_factory=Ball)
+    trail: BallTrail = field(default_factory=BallTrail)
+    server: socket.socket = field(init=False)
+    conn: Optional[socket.socket] = field(default=None, init=False)
+
+    def __post_init__(self):
+        self.server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.server.bind((self.host, self.port))
+        self.server.listen(1)
+
+    def poll_network(self):
+        if self.conn is None:
+            try:
+                self.conn, _ = self.server.accept()
+                self.conn.setblocking(False)
+                print("TCP connection accepted")
+            except BlockingIOError:
+                return
+        try:
+            data = self.conn.recv(4096)
+        except BlockingIOError:
+            return
+        if not data:
+            self.conn.close()
+            self.conn = None
+            return
+        try:
+            shot = json.loads(data.decode())
+        except json.JSONDecodeError:
+            return
+        if shot.get("ShotDataOptions", {}).get("ContainsBallData"):
+            self.trail.clear_points()
+            self.ball.hit_from_data(shot["BallData"])
+            self.track_points = True
+            self.trail.add_point(self.ball.position.copy())
+
+    def step(self, delta: float):
+        self.poll_network()
+        self.ball.update(delta)
+        if self.track_points:
+            self._trail_timer += delta
+            if self._trail_timer >= self.trail_resolution:
+                self.trail.add_point(self.ball.position.copy())
+                self._trail_timer = 0.0
+        self._apex = max(self._apex, self.ball.position[1])
+
+    @property
+    def distance_yards(self):
+        return (self.ball.position[[0,2]] ** 2).sum() ** 0.5 * 1.09361
+
+    @property
+    def apex_feet(self):
+        return self._apex * 3.0

--- a/JaySimG_translation/vector.py
+++ b/JaySimG_translation/vector.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+
+def vec3(x=0.0, y=0.0, z=0.0):
+    return np.array([x, y, z], dtype=float)
+
+
+def length(v):
+    return float(np.linalg.norm(v))
+
+
+def normalized(v):
+    l = length(v)
+    if l == 0:
+        return vec3()
+    return v / l
+
+
+def cross(a, b):
+    return np.cross(a, b)
+
+
+def dot(a, b):
+    return float(np.dot(a, b))

--- a/JaySimG_translation/visualize_flight.py
+++ b/JaySimG_translation/visualize_flight.py
@@ -1,0 +1,51 @@
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+from .ball import Ball
+
+
+def simulate_shot(data, delta=0.01, max_time=20.0):
+    ball = Ball()
+    ball.hit_from_data(data)
+    positions = [ball.position.copy()]
+    time = 0.0
+    while time < max_time:
+        ball.update(delta)
+        positions.append(ball.position.copy())
+        time += delta
+        if ball.position[1] <= 0.0 and np.linalg.norm(ball.velocity) < 0.01:
+            break
+    return np.array(positions), time
+
+
+def main():
+    data = {
+        "Speed": 100.0,  # mph
+        "VLA": 20.8,     # vertical launch angle
+        "HLA": 1.7,      # horizontal launch angle
+        "TotalSpin": 7494.0,  # rpm
+        "SpinAxis": 2.7,      # degrees
+    }
+    positions, flight_time = simulate_shot(data)
+    distance = np.linalg.norm(positions[-1][[0, 2]])
+    apex = positions[:, 1].max()
+    print(f"Carry Distance: {distance:.2f} m")
+    print(f"Time of Flight: {flight_time:.2f} s")
+    print(f"Apex Height: {apex:.2f} m")
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    ax.plot(positions[:, 0], positions[:, 2], positions[:, 1])
+    ax.set_xlabel('X (m)')
+    ax.set_ylabel('Z (m)')
+    ax.set_zlabel('Y (m)')
+    ax.set_title('Shot Trajectory')
+    plt.tight_layout()
+    plt.savefig('trajectory.png')
+    print("Saved trajectory to trajectory.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_translation.py
+++ b/test_translation.py
@@ -1,0 +1,40 @@
+import numpy as np
+from JaySimG_translation.ball import Ball
+
+
+def test_ball_update_gravity():
+    b = Ball()
+    b.reset()
+    start_y = b.position[1]
+    b.update(0.1)
+    assert b.position[1] < start_y
+
+
+def test_ball_hit_velocity():
+    b = Ball()
+    b.hit()
+    assert np.linalg.norm(b.velocity) > 0
+
+
+def test_ball_hit_from_data_move():
+    b = Ball()
+    data = {
+        "Speed": 100.0,
+        "VLA": 20.0,
+        "HLA": 5.0,
+        "TotalSpin": 3000.0,
+        "SpinAxis": 2.0,
+    }
+    b.hit_from_data(data)
+    b.update(0.1)
+    assert not np.allclose(b.position[[0, 2]], 0.0)
+
+
+def test_ball_eventually_rests():
+    b = Ball()
+    b.hit()
+    for _ in range(2000):
+        b.update(0.01)
+    assert b.position[1] == 0.0
+    assert np.linalg.norm(b.velocity) == 0.0
+


### PR DESCRIPTION
## Summary
- provide guidance in README about running a sample shot
- add `visualize_flight.py` that simulates a shot and saves a 3D trajectory plot

## Testing
- `python -m py_compile JaySimG_translation/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f90d3690483318fd1e3fba7310420