### PR TITLE
Add web server for 3D golf shot visualization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 numpy>=1.21.0
 opencv-python>=4.5.0
 matplotlib>=3.4.0 
+fastapi>=0.110
+uvicorn>=0.23

--- a/webserver/README.md
+++ b/webserver/README.md
@@ -1,0 +1,20 @@
+# Golf Range Visualization Server
+
+This directory contains a small FastAPI application that exposes the physics model
+from `JaySimG_translation` via a web interface. The server computes the trajectory
+of a golf ball and streams the positions to a simple Three.js viewer.
+
+## Usage
+
+Install the required dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+Run the server:
+```bash
+python -m webserver.main
+```
+
+Open `http://localhost:8000` in your browser and click **Hit Ball** to simulate a
+shot using the default parameters. The ball path will be animated in 3D.

--- a/webserver/main.py
+++ b/webserver/main.py
@@ -1,0 +1,46 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+import os
+import sys
+import numpy as np
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from JaySimG_translation.ball import Ball
+
+app = FastAPI(title="Golf Range Visualizer")
+
+STATIC_DIR = os.path.join(os.path.dirname(__file__), 'static')
+app.mount('/static', StaticFiles(directory=STATIC_DIR), name='static')
+
+
+@app.get('/')
+def index():
+    return FileResponse(os.path.join(STATIC_DIR, 'index.html'))
+
+
+@app.post('/simulate')
+async def simulate(request: Request):
+    data = await request.json()
+    ball = Ball()
+    if data:
+        ball.hit_from_data(data)
+    else:
+        ball.hit()
+    positions = []
+    delta = 0.01
+    max_time = 20.0
+    t = 0.0
+    while t < max_time:
+        ball.update(delta)
+        positions.append(ball.position.tolist())
+        t += delta
+        if ball.position[1] <= 0.0 and np.linalg.norm(ball.velocity) < 0.01:
+            break
+    return {"positions": positions}
+
+
+if __name__ == '__main__':
+    import uvicorn
+    port = int(os.getenv('PORT', '8000'))
+    uvicorn.run(app, host='0.0.0.0', port=port)

--- a/webserver/static/index.html
+++ b/webserver/static/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Golf Range Visualizer</title>
+    <style>
+        body, html { margin:0; padding:0; width:100%; height:100%; overflow:hidden; }
+        #container { width:100%; height:100%; }
+        #ui { position:absolute; top:10px; left:10px; z-index:10; }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.min.js"></script>
+</head>
+<body>
+<div id="ui">
+    <button id="start">Hit Ball</button>
+</div>
+<div id="container"></div>
+<script>
+const container = document.getElementById('container');
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth/window.innerHeight, 0.1, 500);
+const renderer = new THREE.WebGLRenderer({antialias:true});
+renderer.setSize(window.innerWidth, window.innerHeight);
+container.appendChild(renderer.domElement);
+
+const groundGeo = new THREE.PlaneGeometry(200,200);
+const groundMat = new THREE.MeshBasicMaterial({color:0x228B22});
+const ground = new THREE.Mesh(groundGeo, groundMat);
+ground.rotation.x = -Math.PI/2;
+scene.add(ground);
+
+const ballGeo = new THREE.SphereGeometry(0.021,16,16);
+const ballMat = new THREE.MeshBasicMaterial({color:0xffffff});
+const ball = new THREE.Mesh(ballGeo, ballMat);
+scene.add(ball);
+
+camera.position.set(0,5,10);
+const controls = {positions:[], idx:0};
+
+function animate(){
+    requestAnimationFrame(animate);
+    if(controls.positions.length && controls.idx < controls.positions.length){
+        const p = controls.positions[controls.idx];
+        ball.position.set(p[0], p[1], p[2]);
+        controls.idx += 1;
+    }
+    renderer.render(scene, camera);
+}
+animate();
+
+document.getElementById('start').onclick = async () => {
+    const res = await fetch('/simulate', {method:'POST', headers:{'Content-Type':'application/json'}, body:'{}'});
+    const data = await res.json();
+    controls.positions = data.positions;
+    controls.idx = 0;
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement a small FastAPI app in `webserver` using the JaySimG translation
- serve a simple Three.js viewer for ball trajectories
- add FastAPI and Uvicorn to requirements

## Testing
- `python -m py_compile webserver/main.py`
- `PORT=8001 python -m webserver.main & sleep 2; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_683fc051c3288331ab24018b7d2646a7