### PR TITLE
Add linear algebra spin notebook

### DIFF
--- a/linearalg_spin.ipynb
+++ b/linearalg_spin.ipynb
@@ -2,36 +2,196 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "6f5a8db2",
    "metadata": {},
-   "source": []
+   "source": [
+    "# Linear Algebra of Golf Ball Rotation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "248924b2",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates how 2-D images of a golf ball can be \n",
+    "projected onto a 3-D model in order to analyze its rotation.\n",
+    "We use linear algebra concepts such as projection and rotation matrices \n",
+    "and leverage the `ProjectOp` utility from this repository."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b32cfcb9",
+   "metadata": {},
+   "source": [
+    "## 1. Mapping 2‑D Pixels to the Ball Surface\n",
+    "\n",
+    "Given a detected ball center `(c_x, c_y)` and radius `r`, any pixel `(x, y)`\n",
+    "within the circle can be mapped to 3‑D coordinates on the hemisphere:\n",
+    "\n",
+    "$$x' = x - c_x,\\quad y' = y - c_y$$\n",
+    "$$z' = \\sqrt{r^2 - x'^2 - y'^2}$$\n",
+    "\n",
+    "This yields a point **p** = `(x', y', z')` on the ball surface."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1c5ffbaf",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "def map_to_ball(x, y, c_x, c_y, r):\n",
+    "    x_p = x - c_x\n",
+    "    y_p = y - c_y\n",
+    "    z_sq = r*r - (x_p**2 + y_p**2)\n",
+    "    if z_sq <= 0:\n",
+    "        return None  # off the sphere\n",
+    "    z_p = np.sqrt(z_sq)\n",
+    "    return np.array([x_p, y_p, z_p])\n",
+    "\n",
+    "# Example pixel\n",
+    "pt_3d = map_to_ball(110, 95, c_x=100, c_y=100, r=30)\n",
+    "pt_3d"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac548b2d",
+   "metadata": {},
+   "source": [
+    "## 2. Applying a Rotation\n",
+    "\n",
+    "A rotation matrix `R` transforms the 3‑D point on the ball.\n",
+    "Using XYZ Euler angles $\u0007lpha$, $\beta$, $\\gamma$ (side‑spin, back‑spin, axial‑spin):\n",
+    "\n",
+    "$$R = R_z(\\gamma) R_y(\beta) R_x(\u0007lpha)$$\n",
+    "\n",
+    "The rotated point is $p_r = R p$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "437a48f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def euler_rotate(pt, angles_deg):\n",
+    "    ax, ay, az = np.deg2rad(angles_deg)\n",
+    "    Rx = np.array([[1, 0, 0],\n",
+    "                   [0, np.cos(ax), -np.sin(ax)],\n",
+    "                   [0, np.sin(ax),  np.cos(ax)]])\n",
+    "    Ry = np.array([[ np.cos(ay), 0, np.sin(ay)],\n",
+    "                   [0, 1, 0],\n",
+    "                   [-np.sin(ay), 0, np.cos(ay)]])\n",
+    "    Rz = np.array([[np.cos(az), -np.sin(az), 0],\n",
+    "                   [np.sin(az),  np.cos(az), 0],\n",
+    "                   [0, 0, 1]])\n",
+    "    R = Rz @ Ry @ Rx\n",
+    "    return R @ pt\n",
+    "\n",
+    "rotated = euler_rotate(pt_3d, (10, 20, 30))\n",
+    "rotated"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf71f7cb",
+   "metadata": {},
+   "source": [
+    "## 3. Using `ProjectOp`\n",
+    "\n",
+    "`ProjectOp` encapsulates the above mapping and rotation steps.\n",
+    "It projects each pixel in a grayscale image to the ball surface,\n",
+    "rotates the point in 3‑D, and samples the new 2‑D position.\n",
+    "This is useful for comparing two frames to estimate spin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1884d37e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from GolfBall import GolfBall\n",
+    "from ProjectOp import ProjectionOp\n",
+    "\n",
+    "ball = GolfBall(x=100, y=100, measured_radius_pixels=30)\n",
+    "output = np.zeros((200, 200, 2), dtype=np.int32)\n",
+    "op = ProjectionOp(ball, output, np.radians(-10), np.radians(20), np.radians(30))\n",
+    "\n",
+    "# project a single pixel value onto the rotated ball\n",
+    "op(255, 110, 95)\n",
+    "output[95, 110]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f725840a",
+   "metadata": {},
+   "source": [
+    "## 4. Recovering Rotation\n",
+    "\n",
+    "By comparing how features move between two frames, we search for\n",
+    "the Euler angles that best align the projected images.\n",
+    "`GetBallRotation.py` automates this search over a grid of rotations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c302bd32",
+   "metadata": {},
+   "source": [
+    "## 5. Demo: Rotating a Sample Image\n",
+    "\n",
+    "Load a grayscale image, rotate it using `get_rotated_image`, and display the result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4734f38a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cv2\n",
+    "import matplotlib.pyplot as plt\n",
+    "from GolfBall import GolfBall\n",
+    "from GetRotatedImage import get_rotated_image\n",
+    "\n",
+    "img = cv2.imread(\"data/Images/image.png\", cv2.IMREAD_GRAYSCALE)\n",
+    "ball = GolfBall(x=img.shape[1]//2, y=img.shape[0]//2,\n",
+    "                measured_radius_pixels=min(img.shape)//4,\n",
+    "                angles_camera_ortho_perspective=(0,0,0))\n",
+    "rot_img = get_rotated_image(img, ball, (20, 30, 45))\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(8,4))\n",
+    "axes[0].imshow(img, cmap='gray')\n",
+    "axes[0].set_title('Original')\n",
+    "axes[0].axis('off')\n",
+    "axes[1].imshow(rot_img, cmap='gray')\n",
+    "axes[1].set_title('Rotated')\n",
+    "axes[1].axis('off')\n",
+    "plt.show()"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- flesh out `linearalg_spin.ipynb` with a basic intro to ball projection/rotation
- add a demo cell showing how to rotate an example image

## Testing
- `python - <<'EOF'
import cv2
from GolfBall import GolfBall
from GetRotatedImage import get_rotated_image
img = cv2.imread('data/Images/image.png', cv2.IMREAD_GRAYSCALE)
ball = GolfBall(x=img.shape[1]//2, y=img.shape[0]//2, measured_radius_pixels=min(img.shape)//4, angles_camera_ortho_perspective=(0,0,0))
rot_img = get_rotated_image(img, ball, (20,30,45))
print(rot_img.shape, rot_img.dtype)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6848a44f6f788331ac75796d6d48ba8a