### PR TITLE
Update FormatImage to use YOLO-based detection

### DIFF
--- a/image_processing/FormatImage.py
+++ b/image_processing/FormatImage.py
@@ -1,33 +1,27 @@
 import cv2
 import numpy as np
 from spin.GolfBall import GolfBall
-# Import the circle detection helpers
-from .ballDetection import run_hough_with_radius, auto_determine_circle_radius
-from .Convert_Canny import convert_to_canny
+from .ballDetection import detect_golfballs
+
 def format_image_to_golfball(image_path: str) -> GolfBall:
     """
-    Formats an image to a GolfBall class instance by detecting the golf ball outline
-    and determining its radius using the Hough Circle Transform.
+    Detect a golf ball in ``image_path`` using the YOLO model and return it as a
+    :class:`GolfBall` instance.
 
     Args:
         image_path: Path to the image file.
 
     Returns:
-        A GolfBall instance with detected x, y coordinates and measured radius.
+        A ``GolfBall`` with detected center coordinates and radius in pixels.
     """
-    # Read the image
-    img = cv2.imread(image_path, cv2.IMREAD_GRAYSCALE)
-    
 
-    # Automatically determine the radius of the circle
-    radius = auto_determine_circle_radius(image_path)
-    canny = convert_to_canny(image_path)
-    # Run Hough Circle Transform to detect circles
-    circles = run_hough_with_radius(canny, radius)
-    
-    # Assuming the first detected circle is the golf ball
-    if circles is not None and len(circles) > 0:
+    # Load the image in BGR so the detector can run on colour data
+    img = cv2.imread(image_path)
+
+    circles = detect_golfballs(img, display=False)
+
+    if circles:
         x, y, r = circles[0]
-        return GolfBall(x=x, y=y, measured_radius_pixels=r, angles_camera_ortho_perspective=(0.0, 0.0, 0.0))
-    else:
-        raise ValueError("No golf ball detected in the image.")
+        return GolfBall(x=x, y=y, measured_radius_pixels=r,
+                        angles_camera_ortho_perspective=(0.0, 0.0, 0.0))
+    raise ValueError("No golf ball detected in the image.")

--- a/image_processing/ballDetection.py
+++ b/image_processing/ballDetection.py
@@ -11,7 +11,7 @@ CLASS_ID    = 0   # change if your golf ball class id != 0
 # ---------- YOLO STUFF ----------
 model = YOLO(MODEL_PATH)
 
-def detect_golfballs(image, conf=0.25, imgsz=640):
+def detect_golfballs(image, conf=0.25, imgsz=640, display=True):
     """
     Run YOLO on an image (path or ndarray) and return a list of (x_center, y_center, r_pixels).
     r is approximated from the bbox as the average of half-width & half-height.
@@ -35,19 +35,21 @@ def detect_golfballs(image, conf=0.25, imgsz=640):
         x_center, y_center = x_min + width // 2, y_min + height // 2
         circle_data.append((x_center, y_center, radius))
 
-        # Draw the bounding box and label on the image for debugging
-        cv2.rectangle(image, (x_min, y_min), (x_max, y_max), (0, 255, 0), 2)
-        label = f"Golf Ball: {int(box.cls.item())}"
-        cv2.putText(image, label, (x_min, y_min - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 2)
+        if display:
+            # Draw the bounding box and label on the image for debugging
+            cv2.rectangle(image, (x_min, y_min), (x_max, y_max), (0, 255, 0), 2)
+            label = f"Golf Ball: {int(box.cls.item())}"
+            cv2.putText(image, label, (x_min, y_min - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 2)
 
     # sort left→right like your original code
     circle_data.sort(key=lambda c: c[0])
     print(f"Detected {len(circle_data)} golf ball(s).")
 
-    # Display the image with bounding boxes and labels
-    cv2.imshow("Detected Golf Balls", image)
-    cv2.waitKey(0)
-    cv2.destroyAllWindows()
+    if display:
+        # Display the image with bounding boxes and labels
+        cv2.imshow("Detected Golf Balls", image)
+        cv2.waitKey(0)
+        cv2.destroyAllWindows()
 
     return circle_data
 


### PR DESCRIPTION
## Summary
- support optional display in `ballDetection.detect_golfballs`
- switch `FormatImage.format_image_to_golfball` to YOLO detection

## Testing
- `python -m py_compile image_processing/ballDetection.py image_processing/FormatImage.py`

------
https://chatgpt.com/codex/tasks/task_e_688154cebb08833196b349b19dccef23