### PR TITLE
Fix FPS zero division in movement monitor

### DIFF
--- a/camera/cv_grab_callback.py
+++ b/camera/cv_grab_callback.py
@@ -135,7 +135,8 @@ def process_frames(cam,
                 diff = cv2.absdiff(original_cropped_roi, crop)
                 md = np.mean(diff)
                 frame_count += 1
-                fps = frame_count / (time.time() - start_time)
+                elapsed = time.time() - start_time
+                fps = frame_count / elapsed if elapsed > 0 else 0.0
                 print(f"Comparison FPS: {fps:.1f}, Mean Difference: {md:.2f}")
 
                 if md > movement_threshold and not is_recording:


### PR DESCRIPTION
## Summary
- handle elapsed time == 0 when computing FPS

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68856fcdd13c833197bb75fec676f737