### PR TITLE
Add pytest-based unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_ball_utils.py
+++ b/tests/test_ball_utils.py
@@ -1,0 +1,30 @@
+import numpy as np
+from trajectory_simulation.vector import vec3, length
+from trajectory_simulation.ball import project, angle_between, limit_length, rotation_matrix
+
+
+def test_project():
+    v = vec3(1, 2, 0)
+    n = vec3(0, 1, 0)
+    p = project(v, n)
+    np.testing.assert_allclose(p, vec3(0, 2, 0))
+
+
+def test_angle_between():
+    a = vec3(1, 0, 0)
+    b = vec3(0, 1, 0)
+    angle = angle_between(a, b)
+    assert np.isclose(angle, np.pi / 2)
+
+
+def test_limit_length():
+    v = vec3(3, 4, 0)
+    limited = limit_length(v, 2)
+    assert np.isclose(length(limited), 2)
+    np.testing.assert_array_equal(limit_length(vec3(1, 1, 0), 5), vec3(1, 1, 0))
+
+
+def test_rotation_matrix():
+    R = rotation_matrix(vec3(0, 0, 1), np.pi / 2)
+    rotated = R @ vec3(1, 0, 0)
+    np.testing.assert_allclose(np.round(rotated, 5), vec3(0, 1, 0))

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -1,0 +1,100 @@
+import numpy as np
+import pytest
+cv2 = pytest.importorskip("cv2")
+
+from image_processing.Convert_GrayScale import convert_to_grayscale
+from image_processing.Convert_Canny import convert_to_canny
+from image_processing.ImageCompressor import compress_image
+from image_processing.RemoveReflection import remove_reflections
+from image_processing.movementDetection import has_ball_moved
+from image_processing.launchAngleCalculation import calculate_launch_angle as calc_launch
+from image_processing.ballSpeedCalculation import calculate_ball_speed
+import spin.GetLaunchAngle as GetLaunchAngle
+
+
+def test_convert_to_grayscale(tmp_path):
+    img = np.zeros((10, 10, 3), dtype=np.uint8)
+    path = tmp_path / "img.png"
+    cv2.imwrite(str(path), img)
+    gray = convert_to_grayscale(str(path))
+    assert gray.shape == (10, 10)
+    assert gray.dtype == np.uint8
+
+
+def test_convert_to_canny(tmp_path):
+    img = np.zeros((10, 10), dtype=np.uint8)
+    img[4:6, 4:6] = 255
+    path = tmp_path / "edge.png"
+    cv2.imwrite(str(path), img)
+    edges = convert_to_canny(str(path))
+    assert edges.shape == img.shape
+    assert edges.sum() > 0
+
+
+def test_compress_image():
+    img = np.ones((10, 10), dtype=np.uint8) * 255
+    out = compress_image(img, 2)
+    assert out.shape == (5, 5)
+    with pytest.raises(ValueError):
+        compress_image(img, -1)
+
+
+def test_remove_reflections():
+    orig = np.array([[0, 255], [0, 0]], dtype=np.uint8)
+    filtered = orig.copy()
+    out = remove_reflections(orig, filtered)
+    assert out[0, 1] == 128
+
+
+def test_has_ball_moved(monkeypatch):
+    def fake_delta(a, b):
+        return 0.0, 0.02, 0.0
+    monkeypatch.setattr('image_processing.movementDetection.delta_similarity', fake_delta)
+    prev = np.zeros((5, 5, 3), dtype=np.uint8)
+    curr = np.zeros((5, 5, 3), dtype=np.uint8)
+    moved, delta = has_ball_moved(prev, curr, (0, 0, 5, 5))
+    assert moved is True
+    assert delta == 0.02
+
+
+def test_has_ball_moved_empty():
+    prev = np.zeros((5, 5, 3), dtype=np.uint8)
+    curr = np.zeros((5, 5, 3), dtype=np.uint8)
+    moved, delta = has_ball_moved(prev, curr, (6, 6, 8, 8))
+    assert moved is False
+    assert delta == 0.0
+
+
+def test_launch_angle_calculation():
+    det1 = (0, 10, 10)
+    det2 = (10, 0, 10)
+    angle = calc_launch(det1, det2)
+    assert pytest.approx(angle, rel=1e-5) == 45.0
+
+
+def test_ball_speed(monkeypatch):
+    def fake_detect(img):
+        if fake_detect.calls == 0:
+            fake_detect.calls += 1
+            return [(5, 5, 10)]
+        return [(15, 5, 10)]
+    fake_detect.calls = 0
+    monkeypatch.setattr('image_processing.ballSpeedCalculation.detect_golfballs', fake_detect)
+    frame1 = np.zeros((20, 20, 3), dtype=np.uint8)
+    frame2 = np.zeros((20, 20, 3), dtype=np.uint8)
+    speed = calculate_ball_speed(frame1, frame2, 0.01, return_mph=True)
+    assert pytest.approx(speed, rel=1e-2) == 4.77
+
+
+def test_get_launch_angle(monkeypatch):
+    def fake_detect(img):
+        if fake_detect.calls == 0:
+            fake_detect.calls += 1
+            return [(10, 20, 5)]
+        return [(20, 10, 5)]
+    fake_detect.calls = 0
+    monkeypatch.setattr(GetLaunchAngle, 'detect_golfballs', fake_detect)
+    frame1 = np.zeros((30, 30), dtype=np.uint8)
+    frame2 = np.zeros((30, 30), dtype=np.uint8)
+    angle = GetLaunchAngle.calculate_launch_angle(frame1, frame2)
+    assert pytest.approx(angle, rel=1e-5) == 45.0

--- a/tests/test_range_and_trail.py
+++ b/tests/test_range_and_trail.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+cv2 = pytest.importorskip("cv2")
+
+from trajectory_simulation.ball import Ball
+from trajectory_simulation.ball_trail import BallTrail
+from trajectory_simulation.range import RangeSim
+from trajectory_simulation.flightDataCalculation import calculate_descending_angle, get_trajectory_metrics
+
+
+def test_ball_trail():
+    trail = BallTrail()
+    trail.add_point([1, 2, 3])
+    np.testing.assert_array_equal(trail.points[-1], np.array([1, 2, 3]))
+    trail.clear_points()
+    assert len(trail.points) == 2
+
+
+def test_range_properties():
+    rs = RangeSim.__new__(RangeSim)
+    rs.ball = Ball()
+    rs.ball.position = np.array([10.0, 2.0, 0.0])
+    rs._apex = 5.0
+    assert pytest.approx(rs.distance_yards, rel=1e-5) == np.linalg.norm([10.0, 0.0]) * 1.09361
+    assert rs.apex_feet == 15.0
+
+
+def test_calculate_descending_angle():
+    positions = np.array([[0, 1, 0], [1, 2, 0], [2, 0, 0]], dtype=float)
+    angle = calculate_descending_angle(positions, 2)
+    assert pytest.approx(angle, rel=1e-5) == -45.0
+
+
+def test_get_trajectory_metrics(monkeypatch):
+    import trajectory_simulation.flightDataCalculation as fdc
+
+    def fake_simulate(data, delta=0.01, max_time=20.0):
+        return np.array([[0, 0, 0], [10, 5, 0], [20, 0, 0]]), 2.0
+
+    monkeypatch.setattr(fdc, 'simulate_shot', fake_simulate)
+    metrics, pos = get_trajectory_metrics({})
+    assert metrics['carry_distance'] > 0
+    assert metrics['total_distance'] > 0
+    assert metrics['apex'] == pytest.approx(5 * 3.28084)
+    assert metrics['time_of_flight'] == 2.0
+    assert 'descending_angle' in metrics
+    assert pos.shape[0] == 3

--- a/tests/test_spin.py
+++ b/tests/test_spin.py
@@ -1,0 +1,15 @@
+import numpy as np
+from spin.Vector2RPM import calculate_spin_components
+from spin.spinAxis import calculate_spin_axis
+
+
+def test_calculate_spin_components():
+    sidespin, backspin, total = calculate_spin_components([360, 0, 0], 1000)
+    assert np.isclose(sidespin, 60)
+    assert np.isclose(backspin, 0)
+    assert np.isclose(total, 60)
+
+
+def test_calculate_spin_axis():
+    assert calculate_spin_axis(2000, 1000) == 22.5
+    assert calculate_spin_axis(2000, -1000) == -22.5

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -1,0 +1,24 @@
+import numpy as np
+from trajectory_simulation.vector import vec3, length, normalized, cross, dot
+
+
+def test_vec3_creation():
+    v = vec3(1, 2, 3)
+    assert isinstance(v, np.ndarray)
+    np.testing.assert_array_equal(v, np.array([1.0, 2.0, 3.0]))
+
+
+def test_length_and_normalized():
+    v = vec3(3, 4, 0)
+    assert length(v) == 5.0
+    n = normalized(v)
+    np.testing.assert_allclose(n, v / 5.0)
+    np.testing.assert_array_equal(normalized(vec3()), vec3())
+
+
+def test_cross_and_dot():
+    a = vec3(1, 0, 0)
+    b = vec3(0, 1, 0)
+    np.testing.assert_array_equal(cross(a, b), vec3(0, 0, 1))
+    assert dot(a, b) == 0.0
+    assert dot(a, a) == 1.0


### PR DESCRIPTION
## Summary
- add a `conftest.py` to set up import paths for tests
- create tests for vector utilities, ball helpers, spin computations
- test basic image processing helpers with OpenCV available
- add physics and range related tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d93da0908331b9f0db1bcf069fde