### PR TITLE
feat: make hitting zone check optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ GCFive provides a set of utilities for capturing high‑speed camera frames of a
   ```bash
   python main.py
   ```
-  The script connects to the camera, waits for a ball to appear in the predefined zone and records a short burst of frames. Press `q` in the display window to exit.
+  The script connects to the camera, waits for a ball to appear in the predefined zone and records a short burst of frames. Press `q` in the display window to exit. To skip the zone requirement and trigger recording as soon as a ball is detected, set `[Detection] use_hitting_zone = false` in `config.cfg`.
 - **Estimate spin between two images**
   ```bash
   python spin/GetBallRotation.py image1.png image2.png

--- a/config.cfg
+++ b/config.cfg
@@ -17,6 +17,9 @@ roi_y = 100
 exposure_us = 500
 has_external_detector = true
 
+[Detection]
+use_hitting_zone = true
+
 [Benchmark]
 total_frames = 1600
 workers = 4

--- a/main.py
+++ b/main.py
@@ -29,6 +29,7 @@ YOLO_IMGSZ = CONFIG.getint("YOLO", "imgsz", fallback=640)
 RECALIBRATE_HITTING_ZONE = CONFIG.getboolean(
     "Calibration", "recalibrate_hitting_zone", fallback=False
 )
+USE_HITTING_ZONE = CONFIG.getboolean("Detection", "use_hitting_zone", fallback=True)
 
 
 def main():
@@ -78,18 +79,21 @@ def main():
                 )
                 detected_circle = (center_x, center_y, radius)
 
-                # Check if the detected ball is within the predefined zone
-                if is_point_in_zone(ballx, ballz):
-                    print("Ball is within the zone.")
+                # Optionally check if the detected ball is within the predefined zone
+                if USE_HITTING_ZONE and not is_point_in_zone(ballx, ballz):
+                    print("Ball is outside the zone.")
+                    stationary_start_time = None
+                    continue
+                else:
+                    if USE_HITTING_ZONE:
+                        print("Ball is within the zone.")
+                    else:
+                        print("Zone check disabled.")
                     if stationary_start_time is None:
                         stationary_start_time = time.time()
                     elif time.time() - stationary_start_time >= 3:
                         ball_detected = True
                         print("Ball has been stationary for over 3 seconds.")
-                else:
-                    print("Ball is outside the zone.")
-                    stationary_start_time = None
-                    continue
 
                 # Calculate crop coordinates
                 crop_size = 100  # Size of the square crop around the ball


### PR DESCRIPTION
## Summary
- allow bypassing hitting zone verification via new `[Detection] use_hitting_zone` config flag
- document optional zone check in README
- respect flag in main loop so ball detection alone can trigger recording

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c3c96937083318f15273b579d2314