### PR TITLE
Add image-based spin server and client using GetBallRotation

### DIFF
--- a/scripts/backspin_client.py
+++ b/scripts/backspin_client.py
@@ -1,0 +1,48 @@
+"""Client script to request ball spin calculation from the server."""
+
+import base64
+import json
+import socket
+from pathlib import Path
+from typing import Any
+
+HOST = "api.ddxcr.com"  # Server hostname or IP address
+PORT = 65432  # Server port to connect to
+
+
+def _encode_image(path: str | Path) -> str:
+    """Read an image file and return a base64-encoded string."""
+    with open(path, "rb") as img_file:
+        return base64.b64encode(img_file.read()).decode("utf-8")
+
+
+def request_backspin(image1_path: str, image2_path: str) -> Any:
+    """Send two ball images to the server and return the spin calculation."""
+    payload = {
+        "image1": _encode_image(image1_path),
+        "image2": _encode_image(image2_path),
+    }
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.connect((HOST, PORT))
+        s.sendall(json.dumps(payload).encode("utf-8"))
+        data = b""
+        while True:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+
+    return json.loads(data.decode("utf-8"))
+
+
+def main() -> None:
+    """Example usage for requesting a spin calculation."""
+    image1_path = "ball_frame1.jpg"
+    image2_path = "ball_frame2.jpg"
+    result = request_backspin(image1_path, image2_path)
+    print("Spin result:", result)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backspin_server.py
+++ b/scripts/backspin_server.py
@@ -1,0 +1,73 @@
+"""Simple socket server for ball spin calculation using image pairs."""
+
+import base64
+import json
+import socket
+from typing import Any
+
+import cv2
+import numpy as np
+
+from spin.GetBallRotation import get_fine_ball_rotation
+
+HOST = "0.0.0.0"  # Listen on all interfaces
+PORT = 65432  # Port to listen on (non-privileged ports are > 1023)
+
+
+def _decode_image(b64: str) -> np.ndarray:
+    """Decode a base64-encoded image string into a NumPy array."""
+    img_bytes = base64.b64decode(b64)
+    img_array = np.frombuffer(img_bytes, dtype=np.uint8)
+    return cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+
+
+def handle_client(conn: socket.socket) -> None:
+    """Receive image data from *conn*, compute spin and return result.
+
+    Parameters
+    ----------
+    conn:
+        Established socket connection to the client.
+    """
+    with conn:
+        data = b""
+        while True:
+            packet = conn.recv(4096)
+            if not packet:
+                break
+            data += packet
+        if not data:
+            return
+
+        payload: Any = json.loads(data.decode("utf-8"))
+        image1_b64: str = payload["image1"]
+        image2_b64: str = payload["image2"]
+
+        ball_image1 = _decode_image(image1_b64)
+        ball_image2 = _decode_image(image2_b64)
+
+        spin_x, spin_y, spin_z = get_fine_ball_rotation(ball_image1, ball_image2)
+
+        result = {
+            "side_spin_deg": spin_x,
+            "back_spin_deg": spin_y,
+            "axial_spin_deg": spin_z,
+        }
+
+        conn.sendall(json.dumps(result).encode("utf-8"))
+
+
+def main() -> None:
+    """Run the backspin calculation server."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((HOST, PORT))
+        s.listen()
+        print(f"Backspin server listening on {HOST}:{PORT}")
+        while True:
+            conn, addr = s.accept()
+            print(f"Connected by {addr}")
+            handle_client(conn)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- compute spin from image pairs via `get_fine_ball_rotation` in `backspin_server.py`
- send base64 encoded images from client to server
- default client host set to `api.ddxcr.com`

## Testing
- `pre-commit run --files scripts/backspin_server.py scripts/backspin_client.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e3d37ba408331805bb6acfcf20b98