### PR TITLE
Fix config path and add import tests

### DIFF
--- a/tests/test_ball_basic.py
+++ b/tests/test_ball_basic.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+
+from trajectory_simulation.ball import Ball
+from trajectory_simulation.vector import length, vec3
+
+
+def test_ball_reset():
+    b = Ball()
+    b.position[:] = vec3(1, 2, 3)
+    b.velocity[:] = vec3(1, 1, 1)
+    b.omega[:] = vec3(1, 1, 1)
+    b.position_list.append(vec3(1, 2, 3))
+    b.total_position_list.append(vec3(1, 2, 3))
+    b.reset()
+    assert np.allclose(b.position, vec3(0.0, 0.1, 0.0))
+    assert np.allclose(b.velocity, vec3())
+    assert b.position_list == []
+    assert b.total_position_list == []
+
+
+def test_ball_hit_from_data():
+    b = Ball()
+    data = {"Speed": 100, "VLA": 10, "HLA": 5, "TotalSpin": 3000, "SpinAxis": 3}
+    b.hit_from_data(data)
+    assert np.allclose(b.position, vec3(0.0, 0.05, 0.0))
+    assert length(b.velocity) == pytest.approx(data["Speed"] * 0.44704, rel=1e-4)
+    assert length(b.omega) == pytest.approx(data["TotalSpin"] * 0.10472, rel=1e-4)

--- a/tests/test_ballin_zone_check.py
+++ b/tests/test_ballin_zone_check.py
@@ -1,0 +1,23 @@
+import pytest
+
+from image_processing import ballinZoneCheck as bzc
+
+
+def test_order_polygon_and_point_in_poly():
+    points = [(1, 0), (0, 0), (0, 1), (1, 1)]
+    ordered = bzc._order_polygon(points)
+    assert set(ordered) == set(points)
+    poly = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    assert bzc._point_in_poly(0.5, 0.5, poly)
+    assert not bzc._point_in_poly(1.5, 1.5, poly)
+
+
+def test_is_point_in_zone(monkeypatch):
+    samples = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    monkeypatch.setattr(
+        bzc,
+        "load_hitting_zone_samples",
+        lambda file_path="hitting_zone_calibration.json": samples,
+    )
+    assert bzc.is_point_in_zone(0.2, 0.2)
+    assert not bzc.is_point_in_zone(2, 2)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,28 @@
+import importlib
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "utility.backspin_client",
+        "spin.spinAxis",
+        "trajectory_simulation.ball",
+        "trajectory_simulation.vector",
+    ],
+)
+def test_basic_imports(module):
+    if module == "utility.backspin_client":
+        pytest.importorskip(
+            "requests", reason="requests not installed", exc_type=ImportError
+        )
+    importlib.import_module(module)
+
+
+@pytest.mark.parametrize(
+    "module",
+    ["image_processing.FormatImage", "image_processing.Convert_GrayScale"],
+)
+def test_cv2_dependent_imports(module):
+    pytest.importorskip("cv2", reason="OpenCV not installed", exc_type=ImportError)
+    importlib.import_module(module)

--- a/tests/test_launch_angle.py
+++ b/tests/test_launch_angle.py
@@ -1,0 +1,9 @@
+import pytest
+
+from image_processing.launchAngleCalculation import calculate_launch_angle
+
+
+def test_calculate_launch_angle():
+    det1 = (0, 0, 20)
+    det2 = (10, -10, 20)
+    assert calculate_launch_angle(det1, det2) == pytest.approx(45.0)

--- a/tests/test_spin_axis.py
+++ b/tests/test_spin_axis.py
@@ -1,0 +1,11 @@
+import pytest
+
+from spin.spinAxis import calculate_spin_axis
+
+
+def test_spin_axis_positive():
+    assert calculate_spin_axis(1000, 500) == pytest.approx(22.5)
+
+
+def test_spin_axis_negative():
+    assert calculate_spin_axis(1000, -500) == pytest.approx(-22.5)

--- a/tests/test_vector_ops.py
+++ b/tests/test_vector_ops.py
@@ -1,0 +1,13 @@
+import numpy as np
+import pytest
+
+from trajectory_simulation.vector import cross, dot, length, normalized, vec3
+
+
+def test_vector_operations():
+    v = vec3(3, 4, 0)
+    assert length(v) == pytest.approx(5.0)
+    n = normalized(v)
+    assert length(n) == pytest.approx(1.0)
+    assert np.allclose(cross(vec3(1, 0, 0), vec3(0, 1, 0)), vec3(0, 0, 1))
+    assert dot(vec3(1, 2, 3), vec3(4, 5, 6)) == pytest.approx(32.0)

--- a/utility/config_reader.py
+++ b/utility/config_reader.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 def load_config(path: str | None = None) -> configparser.ConfigParser:
     parser = configparser.ConfigParser()
-    cfg_path = Path(path) if path else Path(__file__).with_name("config.cfg")
+    if path:
+        cfg_path = Path(path)
+    else:
+        # Default to the repository's data/config.cfg when no path is provided
+        cfg_path = Path(__file__).resolve().parents[1] / "data" / "config.cfg"
     parser.read(cfg_path)
     return parser
 


### PR DESCRIPTION
## Summary
- load default config from repository `data/config.cfg`
- add tests verifying key modules import without errors
- add unit tests for spin axis, launch angle, polygon zone, vector math, and ball physics

## Testing
- `pre-commit run --files tests/test_spin_axis.py tests/test_launch_angle.py tests/test_ballin_zone_check.py tests/test_vector_ops.py tests/test_ball_basic.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e4935b460833186568c4f716374f6